### PR TITLE
Fix progress bar and page routing and improves Subvenue selector

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,11 +38,7 @@ const App = () => {
         <Route exact path="/vbs" component={VenueSelection} />
         <Route exact path="/vbs/confirmation" component={ConfirmationPage} />
         <Route exact path="/vbs/:venueId" component={SpecificVenue} />
-        <Route
-          exact
-          path="/vbs/:venueName/bookingpage"
-          component={BookingPage}
-        />
+        <Route exact path="/vbs/:venueId/bookingpage" component={BookingPage} />
         <Router path="/Contacts" exact>
           <Contacts />
         </Router>

--- a/src/vbs/pages/BookingPage/BookingPage.js
+++ b/src/vbs/pages/BookingPage/BookingPage.js
@@ -9,7 +9,7 @@ import validator from "validator";
 const BookingPage = () => {
   const { selectedDate, selectedTimeslot, venue, selectedSubvenue } =
     useLocation().state;
-  const { venueName } = useParams();
+  const venueId = useParams().venueId;
   const [email, setEmail] = useState("");
   const [purpose, setPurpose] = useState("");
   const [isActive, setIsActive] = useState(false);
@@ -37,7 +37,7 @@ const BookingPage = () => {
   return (
     <div className="BookingPageMainDiv">
       <div className="Statusbar">
-        <StatusBar stage="3" />
+        <StatusBar stage="3" venue={venue} />
       </div>
       <form className="BookingPageForm" onSubmit={handleSubmit}>
         <div className="contents">
@@ -126,7 +126,7 @@ const BookingPage = () => {
       <div className="bottomNavigation">
         <Link
           class="backButton"
-          to={{ path: `/vbs/${venueName}`, state: { venue } }}
+          to={{ pathname: `/vbs/${venueId}`, state: { venue } }}
         >
           Back
         </Link>

--- a/src/vbs/pages/SpecificVenue/SpecificVenue.js
+++ b/src/vbs/pages/SpecificVenue/SpecificVenue.js
@@ -96,12 +96,12 @@ function SpecificVenue() {
     setIsMobile(window.innerWidth <= 500);
   }
 
-  // useEffect(() => {
-  //   window.addEventListener("resize", handleWindowSizeChange);
-  //   return () => {
-  //     window.removeEventListener("resize", handleWindowSizeChange);
-  //   };
-  // }, []);
+  useEffect(() => {
+    window.addEventListener("resize", handleWindowSizeChange);
+    return () => {
+      window.removeEventListener("resize", handleWindowSizeChange);
+    };
+  }, []);
 
   if (!isMobile) {
     return (

--- a/src/vbs/pages/SpecificVenue/components/SubvenueSelector.css
+++ b/src/vbs/pages/SpecificVenue/components/SubvenueSelector.css
@@ -32,6 +32,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  max-height: unset;
 }
 
 .dropdown__menu div {

--- a/src/vbs/pages/SpecificVenue/components/SubvenueSelector.js
+++ b/src/vbs/pages/SpecificVenue/components/SubvenueSelector.js
@@ -8,14 +8,15 @@ const SubvenueSelector = ({
   subvenues,
   handleSubvenueSelection,
   selectedSubvenue,
-  setSelectedSubvenue,
   parentVenue,
 }) => {
   var options = [{ value: parentVenue.id, label: "Whole Venue" }];
 
-  subvenues.map((subvenue) => {
-    options.push({ value: subvenue._id, label: subvenue.name });
-  });
+  if (subvenues.length > 0) {
+    subvenues.map((subvenue) => {
+      options.push({ value: subvenue._id, label: subvenue.name });
+    });
+  }
 
   return (
     <Dropdown

--- a/src/vbs/pages/SpecificVenue/components/SubvenueSelector.js
+++ b/src/vbs/pages/SpecificVenue/components/SubvenueSelector.js
@@ -12,7 +12,7 @@ const SubvenueSelector = ({
 }) => {
   var options = [{ value: parentVenue.id, label: "Whole Venue" }];
 
-  if (subvenues.length > 0) {
+  if (subvenues.length > 1) {
     subvenues.map((subvenue) => {
       options.push({ value: subvenue._id, label: subvenue.name });
     });

--- a/src/vbs/pages/SpecificVenue/components/SubvenueSelector.js
+++ b/src/vbs/pages/SpecificVenue/components/SubvenueSelector.js
@@ -10,12 +10,17 @@ const SubvenueSelector = ({
   selectedSubvenue,
   parentVenue,
 }) => {
-  var options = [{ value: parentVenue.id, label: "Whole Venue" }];
+  var options;
 
   if (subvenues.length > 1) {
+    options = [{ value: parentVenue.id, label: "Whole Venue" }];
     subvenues.map((subvenue) => {
       options.push({ value: subvenue._id, label: subvenue.name });
     });
+  } else {
+    options = [
+      { value: parentVenue.id, label: parentVenue.name + " - Whole Venue" },
+    ];
   }
 
   return (

--- a/src/vbs/shared/ProgressBar.js
+++ b/src/vbs/shared/ProgressBar.js
@@ -4,9 +4,9 @@ import "./ProgressBar.css";
 import { BsCircleFill } from "react-icons/bs";
 import { Link } from "react-router-dom";
 
-function ProgressBar({ stage }) {
+function ProgressBar({ stage, venue }) {
   let history = useHistory();
-  let { venueName } = useParams("venueName");
+  const venueId = useParams().venueId;
   return (
     <div className="progressBarContainer">
       <div className="dotsAndLines">
@@ -31,7 +31,10 @@ function ProgressBar({ stage }) {
           <Link className="link">VENUE</Link>
         )}
         {stage > 2 && stage < 4 ? (
-          <Link className="link enabled" to={`/vbs/${venueName}`}>
+          <Link
+            className="link enabled"
+            to={{ pathname: `/vbs/${venueId}`, state: { venue } }}
+          >
             DATE
           </Link>
         ) : (

--- a/src/vbs/shared/StatusBar.js
+++ b/src/vbs/shared/StatusBar.js
@@ -2,11 +2,11 @@ import React from "react";
 import "./StatusBar.css";
 import ProgressBar from "./ProgressBar";
 
-const StatusBar = ({ stage }) => {
+const StatusBar = ({ stage, venue }) => {
   return (
     <div className="statusBarContainer">
       <h1 className="vbs">VENUE BOOKING SYSTEM</h1>
-      <ProgressBar stage={stage} />
+      <ProgressBar stage={stage} venue={venue} />
     </div>
   );
 };


### PR DESCRIPTION
Fixes ProgressBar and Page Routing that was broken after implementing fetch

- After fetch was implemented, SpecificVenue Page required a venue state as a prop passed from VenueSelection.js. Hence, the Back Button and Progress Bar routing from the BookingPage, no longer worked as the venue state prop is not passed.
- Issue resolved by passing the prop from BookingPage, to StatusBar.js to ProgressBar.js. state also passed thru Back Button

Improves Subvenue Selector:

- Venues with no Subvenue, e.g. Band Room will now only appear as one option in the Subvenue Selector.